### PR TITLE
Refactor Player Ship to use Stats

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -225,6 +225,11 @@ _global_script_classes=[ {
 "path": "res://src/Ships/Player/StatsCargo.gd"
 }, {
 "base": "Stats",
+"class": "StatsGun",
+"language": "GDScript",
+"path": "res://src/Ships/Player/StatsGun.gd"
+}, {
+"base": "Stats",
 "class": "StatsShip",
 "language": "GDScript",
 "path": "res://src/Ships/Player/StatsShip.gd"
@@ -273,6 +278,7 @@ _global_script_class_icons={
 "Station": "",
 "Stats": "",
 "StatsCargo": "",
+"StatsGun": "",
 "StatsShip": ""
 }
 

--- a/project/project.godot
+++ b/project/project.godot
@@ -9,6 +9,11 @@
 config_version=4
 
 _global_script_classes=[ {
+"base": "Range",
+"class": "AnimatedBar",
+"language": "GDScript",
+"path": "res://src/Ships/Player/AnimatedBar.gd"
+}, {
 "base": "DockingPoint",
 "class": "Asteroid",
 "language": "GDScript",

--- a/project/project.godot
+++ b/project/project.godot
@@ -14,6 +14,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/World/DockingPoint/Asteroid.gd"
 }, {
+"base": "Node",
+"class": "Cargo",
+"language": "GDScript",
+"path": "res://src/Ships/Player/Cargo.gd"
+}, {
 "base": "Node2D",
 "class": "DockingPoint",
 "language": "GDScript",
@@ -180,6 +185,11 @@ _global_script_classes=[ {
 "path": "res://src/Utils/MathUtils.gd"
 }, {
 "base": "KinematicBody2D",
+"class": "PlayerShip",
+"language": "GDScript",
+"path": "res://src/Ships/Player/PlayerShip.gd"
+}, {
+"base": "KinematicBody2D",
 "class": "Projectile",
 "language": "GDScript",
 "path": "res://src/Ships/Guns/Projectiles/Projectile.gd"
@@ -205,12 +215,19 @@ _global_script_classes=[ {
 "path": "res://src/Ships/Stats.gd"
 }, {
 "base": "Stats",
+"class": "StatsCargo",
+"language": "GDScript",
+"path": "res://src/Ships/Player/StatsCargo.gd"
+}, {
+"base": "Stats",
 "class": "StatsShip",
 "language": "GDScript",
 "path": "res://src/Ships/Player/StatsShip.gd"
 } ]
 _global_script_class_icons={
+"AnimatedBar": "",
 "Asteroid": "",
+"Cargo": "",
 "DockingPoint": "",
 "GSAIAgentLocation": "",
 "GSAIArrive": "",
@@ -244,11 +261,13 @@ _global_script_class_icons={
 "Gun": "",
 "MapIcon": "",
 "MathUtils": "",
+"PlayerShip": "",
 "Projectile": "",
 "State": "",
 "StateMachine": "",
 "Station": "",
 "Stats": "",
+"StatsCargo": "",
 "StatsShip": ""
 }
 

--- a/project/src/Ships/Enemies/Pirate/States/Attack.gd
+++ b/project/src/Ships/Enemies/Pirate/States/Attack.gd
@@ -60,10 +60,8 @@ func physics_process(delta: float) -> void:
 	var facing_direction := GSAIUtils.angle_to_vector2(owner.agent.orientation)
 	var to_player := GSAIUtils.to_vector2(owner.agent.position - target.position).normalized()
 	var player_dot_facing := facing_direction.dot(to_player)
-	
-	if (
-		player_dot_facing > 1-firing_alignment_tolerance_percentage
-	):
+
+	if player_dot_facing > 1 - firing_alignment_tolerance_percentage:
 		owner.gun.fire(owner.gun.global_position, owner.agent.orientation, owner.projectile_mask)
 	if owner.is_squad_leader:
 		var distance_to := starting_position.distance_squared_to(owner.global_position)

--- a/project/src/Ships/Guns/Gun.gd
+++ b/project/src/Ships/Guns/Gun.gd
@@ -1,14 +1,17 @@
 # Spawns, positions and configures a Projectile instance in space and registers
-# it into the global projectiles registry. Firing rate is controlled via a 
+# it into the global projectiles registry. Firing rate is controlled via a
 # cooldown timer.
 class_name Gun
 extends Node2D
 
 export var Projectile: PackedScene
-
-var damage_bonus := 0.0
+export var stats: Resource = preload("res://src/Ships/Player/player_gun_stats.tres")
 
 onready var cooldown: Timer = $Cooldown
+
+
+func _ready() -> void:
+	cooldown.wait_time = stats.get_cooldown()
 
 
 func _get_configuration_warning() -> String:
@@ -24,7 +27,13 @@ func fire(spawn_position: Vector2, spawn_orientation: float, projectile_mask: in
 	projectile.rotation = spawn_orientation
 	projectile.collision_mask = projectile_mask
 	projectile.shooter = owner
-	projectile.damage += damage_bonus
+	projectile.damage += stats.get_damage()
 
 	ObjectRegistry.register_projectile(projectile)
 	cooldown.start()
+
+
+func _on_Stats_stat_changed(stat_name: String, _old_value: float, new_value: float) -> void:
+	match stat_name:
+		"cooldown":
+			cooldown.wait_time = new_value

--- a/project/src/Ships/Player/AnimatedBar.gd
+++ b/project/src/Ships/Player/AnimatedBar.gd
@@ -1,0 +1,36 @@
+# Animated bar that reacts to changes in properties from a Stats resource.
+# Pass the stats instance to the `initialize` method to make the bar work.
+class_name AnimatedBar
+extends Range
+
+onready var tween: Tween = $Tween
+
+var stat_value := ""
+var stat_max := ""
+
+
+func initialize(stats: Stats, _stat_value: String, _stat_max: String) -> void:
+	stat_value = _stat_value
+	stat_max = _stat_max
+	stats.connect("stat_changed", self, "_on_Stats_stat_changed")
+	max_value = stats.get_stat(stat_max)
+	animate(stats.get_stat(stat_value))
+
+
+func animate(target_value: float) -> void:
+	if tween.is_active():
+		tween.stop(self)
+	tween.interpolate_property(
+		self, "value", value, target_value, 0.5, Tween.TRANS_QUART, Tween.EASE_OUT
+	)
+	tween.start()
+
+
+func _on_Stats_stat_changed(stat_name: String, _old_value: float, new_value: float) -> void:
+	if not stat_name in [stat_value, stat_name]:
+		return
+	match stat_name:
+		stat_max:
+			max_value = new_value
+		stat_value:
+			animate(new_value)

--- a/project/src/Ships/Player/PlayerShip.gd
+++ b/project/src/Ships/Player/PlayerShip.gd
@@ -31,7 +31,7 @@ func _ready() -> void:
 	stats.connect("health_depleted", self, "die")
 	gun.projectile_mask = projectile_mask
 	ui.initialize(self, cargo)
-	
+
 
 func _toggle_map(map_up: bool, tween_time: float) -> void:
 	if not map_up:
@@ -65,7 +65,6 @@ func _on_damaged(target: Node, amount: int, _origin: Node) -> void:
 		return
 
 	stats.health -= amount
-
 
 # # TODO: Make components subscribe to stat changes and upgrade from there?
 # func _on_Upgrade_Choice_made(choice: int) -> void:

--- a/project/src/Ships/Player/PlayerShip.gd
+++ b/project/src/Ships/Player/PlayerShip.gd
@@ -26,8 +26,7 @@ onready var ui := $BarRig/PlayerShipUI
 
 func _ready() -> void:
 	Events.connect("damaged", self, "_on_damaged")
-	# TODO: restore upgrades
-	# Events.connect("upgrade_choice_made", self, "_on_Upgrade_Choice_made")
+	Events.connect("upgrade_choice_made", self, "_on_Upgrade_Choice_made")
 	stats.connect("health_depleted", self, "die")
 	gun.projectile_mask = projectile_mask
 	ui.initialize(self, cargo)
@@ -66,26 +65,21 @@ func _on_damaged(target: Node, amount: int, _origin: Node) -> void:
 
 	stats.health -= amount
 
-# # TODO: Make components subscribe to stat changes and upgrade from there?
-# func _on_Upgrade_Choice_made(choice: int) -> void:
-# 	match choice:
-# 		Events.UpgradeChoices.HEALTH:
-# 			stats.add_modifier("max_health", 25.0)
-# 			_health = stats.get_max_health()
-# 			health_bar.max_value = stats.get_max_health()
-# 			health_bar.value = _health
-# 		Events.UpgradeChoices.SPEED:
-# 			stats.add_modifier("linear_speed_max", 125.0)
-# 			move_state.linear_speed_max = stats.get_linear_speed_max()
-# 			agent.linear_speed_max = stats.get_linear_speed_max()
-# 		# TODO: Move to the cargo
-# 		Events.UpgradeChoices.CARGO:
-# 			cargo.max_cargo += stats.max_cargo
-# 			cargo_bar.max_value += stats.max_cargo
-# 		Events.UpgradeChoices.MINING:
-# 			cargo.mining_rate += 10
-# 			cargo.unload_rate = max(cargo.unload_rate + 5, cargo.mining_rate)
-# 		# TODO: Move to the weapon
-# 		Events.UpgradeChoices.WEAPON:
-# 			gun.damage_bonus += 2
-# 			gun.cooldown.wait_time *= 0.9
+
+func _on_Upgrade_Choice_made(choice: int) -> void:
+	match choice:
+		Events.UpgradeChoices.HEALTH:
+			stats.add_modifier("max_health", 25.0)
+		Events.UpgradeChoices.SPEED:
+			stats.add_modifier("linear_speed_max", 125.0)
+		Events.UpgradeChoices.CARGO:
+			cargo.stats.add_modifier("max_cargo", 50.0)
+		Events.UpgradeChoices.MINING:
+			cargo.stats.add_modifier("mining_rate", 10.0)
+			cargo.stats.add_modifier("unload_rate", 5.0)
+		Events.UpgradeChoices.WEAPON:
+			gun.stats.add_modifier("damage", 3.0)
+			# That's a limitation of the stats system, modifiers only add or remove values, and they
+			# don't have limits
+			if gun.stats.get_stat("_cooldown") > 0.2:
+				gun.stats.add_modifier("cooldown", -0.05)

--- a/project/src/Ships/Player/PlayerShip.gd
+++ b/project/src/Ships/Player/PlayerShip.gd
@@ -1,10 +1,9 @@
 # Main class to represent the player's physics body. Controls the player's
 # current health and how to operate when an upgrade choice has been made.
+class_name PlayerShip
 extends KinematicBody2D
 
 signal died
-signal health_changed(new_health, old_health)
-signal health_depleted
 
 export var stats: Resource = preload("res://src/Ships/Player/player_stats.tres")
 export (int, LAYERS_2D_PHYSICS) var projectile_mask := 0
@@ -14,28 +13,25 @@ export var map_icon: Resource
 
 var dockables := []
 
-var _health: float = stats.get_max_health() setget _set_health
-
 onready var shape := $CollisionShape
 onready var agent: GSAISteeringAgent = $StateMachine/Move.agent
 onready var camera_transform := $CameraTransform
 onready var timer := $MapTimer
 onready var cargo := $Cargo
-onready var cargo_bar := $BarRig/PlayerUI/Cargo
-onready var health_bar := $BarRig/PlayerUI/Health
 onready var move_state := $StateMachine/Move
 onready var gun := $Gun
+
+onready var ui := $BarRig/PlayerShipUI
 
 
 func _ready() -> void:
 	Events.connect("damaged", self, "_on_damaged")
-	Events.connect("upgrade_choice_made", self, "_on_Upgrade_Choice_made")
-	# TODO: move to health bar
-	health_bar.max_value = stats.get_max_health()
-	health_bar.value = _health
-
+	# TODO: restore upgrades
+	# Events.connect("upgrade_choice_made", self, "_on_Upgrade_Choice_made")
+	stats.connect("health_depleted", self, "die")
 	gun.projectile_mask = projectile_mask
-
+	ui.initialize(self, cargo)
+	
 
 func _toggle_map(map_up: bool, tween_time: float) -> void:
 	if not map_up:
@@ -68,41 +64,29 @@ func _on_damaged(target: Node, amount: int, _origin: Node) -> void:
 	if not target == self:
 		return
 
-	self._health -= amount
+	stats.health -= amount
 
 
-func _set_health(value: float) -> void:
-	var old_health = _health
-	_health = max(0, value)
-	emit_signal("health_changed", _health, old_health)
-	# TODO: move to health bar
-	health_bar.value = _health
-
-	if _health == 0:
-		die()
-		emit_signal("health_depleted")
-
-
-# TODO: Make components subscribe to stat changes and upgrade from there?
-func _on_Upgrade_Choice_made(choice: int) -> void:
-	match choice:
-		Events.UpgradeChoices.HEALTH:
-			stats.add_modifier("max_health", 25.0)
-			_health = stats.get_max_health()
-			health_bar.max_value = stats.get_max_health()
-			health_bar.value = _health
-		Events.UpgradeChoices.SPEED:
-			stats.add_modifier("linear_speed_max", 125.0)
-			move_state.linear_speed_max = stats.get_linear_speed_max()
-			agent.linear_speed_max = stats.get_linear_speed_max()
-		# TODO: Move to the cargo
-		Events.UpgradeChoices.CARGO:
-			cargo.max_cargo += stats.max_cargo
-			cargo_bar.max_value += stats.max_cargo
-		Events.UpgradeChoices.MINING:
-			cargo.mining_rate += 10
-			cargo.unload_rate = max(cargo.unload_rate + 5, cargo.mining_rate)
-		# TODO: Move to the weapon
-		Events.UpgradeChoices.WEAPON:
-			gun.damage_bonus += 2
-			gun.cooldown.wait_time *= 0.9
+# # TODO: Make components subscribe to stat changes and upgrade from there?
+# func _on_Upgrade_Choice_made(choice: int) -> void:
+# 	match choice:
+# 		Events.UpgradeChoices.HEALTH:
+# 			stats.add_modifier("max_health", 25.0)
+# 			_health = stats.get_max_health()
+# 			health_bar.max_value = stats.get_max_health()
+# 			health_bar.value = _health
+# 		Events.UpgradeChoices.SPEED:
+# 			stats.add_modifier("linear_speed_max", 125.0)
+# 			move_state.linear_speed_max = stats.get_linear_speed_max()
+# 			agent.linear_speed_max = stats.get_linear_speed_max()
+# 		# TODO: Move to the cargo
+# 		Events.UpgradeChoices.CARGO:
+# 			cargo.max_cargo += stats.max_cargo
+# 			cargo_bar.max_value += stats.max_cargo
+# 		Events.UpgradeChoices.MINING:
+# 			cargo.mining_rate += 10
+# 			cargo.unload_rate = max(cargo.unload_rate + 5, cargo.mining_rate)
+# 		# TODO: Move to the weapon
+# 		Events.UpgradeChoices.WEAPON:
+# 			gun.damage_bonus += 2
+# 			gun.cooldown.wait_time *= 0.9

--- a/project/src/Ships/Player/PlayerShip.tscn
+++ b/project/src/Ships/Player/PlayerShip.tscn
@@ -56,7 +56,7 @@ update_rotation = false
 [node name="BarRig" type="Node2D" parent="." index="7"]
 script = ExtResource( 13 )
 
-[node name="PlayerUI" parent="BarRig" index="0" instance=ExtResource( 12 )]
+[node name="PlayerShipUI" parent="BarRig" index="0" instance=ExtResource( 12 )]
 margin_top = 30.0
 margin_bottom = 42.0
 

--- a/project/src/Ships/Player/PlayerShipUI.gd
+++ b/project/src/Ships/Player/PlayerShipUI.gd
@@ -5,5 +5,5 @@ onready var cargo_bar: AnimatedBar = $CargoBar
 
 
 func initialize(player_ship, cargo) -> void:
-	health_bar.initialize(player_ship.stats, "health", "_max_health")
-	cargo_bar.initialize(cargo.stats, "cargo", "_max_cargo")
+	health_bar.initialize(player_ship.stats, "health", "max_health")
+	cargo_bar.initialize(cargo.stats, "cargo", "max_cargo")

--- a/project/src/Ships/Player/PlayerShipUI.gd
+++ b/project/src/Ships/Player/PlayerShipUI.gd
@@ -1,0 +1,9 @@
+extends Control
+
+onready var health_bar: AnimatedBar = $HealthBar
+onready var cargo_bar: AnimatedBar = $CargoBar
+
+
+func initialize(player_ship, cargo) -> void:
+	health_bar.initialize(player_ship.stats, "health", "_max_health")
+	cargo_bar.initialize(cargo.stats, "cargo", "_max_cargo")

--- a/project/src/Ships/Player/StatsCargo.gd
+++ b/project/src/Ships/Player/StatsCargo.gd
@@ -29,3 +29,4 @@ func get_unload_rate() -> float:
 
 func set_cargo(value: float) -> void:
 	cargo = clamp(value, 0.0, get_max_cargo())
+	_update("cargo")

--- a/project/src/Ships/Player/StatsCargo.gd
+++ b/project/src/Ships/Player/StatsCargo.gd
@@ -16,15 +16,15 @@ func _init() -> void:
 
 
 func get_max_cargo() -> float:
-	return get_stat("_max_cargo")
+	return get_stat("max_cargo")
 
 
 func get_mining_rate() -> float:
-	return get_stat("_mining_rate")
+	return get_stat("mining_rate")
 
 
 func get_unload_rate() -> float:
-	return get_stat("_unload_rate")
+	return get_stat("unload_rate")
 
 
 func set_cargo(value: float) -> void:

--- a/project/src/Ships/Player/StatsCargo.gd
+++ b/project/src/Ships/Player/StatsCargo.gd
@@ -1,0 +1,31 @@
+# Represents a Cargo's stats, like its max space, etc. The stats are calculated from
+# the instance's properties, with modifiers (upgrades) applied to them internally.
+# To access the final stats, use the `get_*` functions, or call `get_stat()`
+class_name StatsCargo
+extends Stats
+
+export var _max_cargo := 100.0
+export var _mining_rate := 10.0
+export var _unload_rate := 35.0
+
+var cargo := 0.0 setget set_cargo
+
+
+func _init() -> void:
+	_update_all()
+
+
+func get_max_cargo() -> float:
+	return get_stat("_max_cargo")
+
+
+func get_mining_rate() -> float:
+	return get_stat("_mining_rate")
+
+
+func get_unload_rate() -> float:
+	return get_stat("_unload_rate")
+
+
+func set_cargo(value: float) -> void:
+	cargo = clamp(value, 0.0, get_max_cargo())

--- a/project/src/Ships/Player/StatsGun.gd
+++ b/project/src/Ships/Player/StatsGun.gd
@@ -1,0 +1,20 @@
+# Represents a Ship's stats, like its hull's health, its speed, etc. The stats are calculated from
+# the base_* properties, with modifiers (upgrades) applied to them internally.
+# To access the final stats, use the `get_*` functions, or call `get_stat()`
+class_name StatsGun
+extends Stats
+
+export var _damage := 5.0
+export var _cooldown := 0.4
+
+
+func _init() -> void:
+	_update_all()
+
+
+func get_damage() -> float:
+	return get_stat("damage")
+
+
+func get_cooldown() -> float:
+	return get_stat("cooldown")

--- a/project/src/Ships/Player/StatsShip.gd
+++ b/project/src/Ships/Player/StatsShip.gd
@@ -20,23 +20,23 @@ func _init() -> void:
 
 
 func get_max_health() -> float:
-	return get_stat("_max_health")
+	return get_stat("max_health")
 
 
 func get_acceleration_max() -> float:
-	return get_stat("_acceleration_max")
+	return get_stat("acceleration_max")
 
 
 func get_linear_speed_max() -> float:
-	return get_stat("_linear_speed_max")
+	return get_stat("linear_speed_max")
 
 
 func get_angular_speed_max() -> float:
-	return get_stat("_angular_speed_max")
+	return get_stat("angular_speed_max")
 
 
 func get_angular_acceleration_max() -> float:
-	return get_stat("_angular_acceleration_max")
+	return get_stat("angular_acceleration_max")
 
 
 func set_health(value: float) -> void:

--- a/project/src/Ships/Player/StatsShip.gd
+++ b/project/src/Ships/Player/StatsShip.gd
@@ -4,11 +4,15 @@
 class_name StatsShip
 extends Stats
 
+signal health_depleted
+
 export var _max_health := 100.0
 export var _acceleration_max := 15.0
 export var _linear_speed_max := 350.0
 export var _angular_speed_max := 120.0
 export var _angular_acceleration_max := 45.0
+
+var health: float = _max_health setget set_health
 
 
 func _init() -> void:
@@ -33,3 +37,9 @@ func get_angular_speed_max() -> float:
 
 func get_angular_acceleration_max() -> float:
 	return get_stat("_angular_acceleration_max")
+
+
+func set_health(value: float) -> void:
+	health = clamp(value, 0.0, _max_health)
+	if is_equal_approx(health, 0.0):
+		emit_signal("health_depleted")

--- a/project/src/Ships/Player/StatsShip.gd
+++ b/project/src/Ships/Player/StatsShip.gd
@@ -43,3 +43,4 @@ func set_health(value: float) -> void:
 	health = clamp(value, 0.0, _max_health)
 	if is_equal_approx(health, 0.0):
 		emit_signal("health_depleted")
+	_update("health")

--- a/project/src/Ships/Player/cargo_stats.tres
+++ b/project/src/Ships/Player/cargo_stats.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" load_steps=2 format=2]
+
+[ext_resource path="res://src/Ships/Player/StatsCargo.gd" type="Script" id=1]
+
+[resource]
+script = ExtResource( 1 )
+_max_cargo = 100.0
+_mining_rate = 10.0
+_unload_rate = 35.0

--- a/project/src/Ships/Player/player_gun_stats.tres
+++ b/project/src/Ships/Player/player_gun_stats.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" load_steps=2 format=2]
+
+[ext_resource path="res://src/Ships/Player/StatsGun.gd" type="Script" id=1]
+
+[resource]
+script = ExtResource( 1 )
+_damage = 5.0
+_cooldown = 0.4

--- a/project/src/Ships/Player/player_stats.tres
+++ b/project/src/Ships/Player/player_stats.tres
@@ -4,5 +4,8 @@
 
 [resource]
 script = ExtResource( 1 )
-max_health = 120.0
-acceleration_max = 50.0
+_max_health = 100.0
+_acceleration_max = 15.0
+_linear_speed_max = 350.0
+_angular_speed_max = 120.0
+_angular_acceleration_max = 45.0

--- a/project/src/Ships/Stats.gd
+++ b/project/src/Ships/Stats.gd
@@ -77,7 +77,15 @@ func _update_all() -> void:
 
 # Returns a list of stat properties as strings.
 func _get_stats_list() -> PoolStringArray:
-	var ignore := ["resource_local_to_scene", "resource_name", "resource_path", "script", "_stats_list", "_modifiers", "_cache"]
+	var ignore := [
+		"resource_local_to_scene",
+		"resource_name",
+		"resource_path",
+		"script",
+		"_stats_list",
+		"_modifiers",
+		"_cache"
+	]
 	var stats := PoolStringArray()
 	for p in get_property_list():
 		if p.name[0].capitalize() == p.name[0]:

--- a/project/src/Ships/Stats.gd
+++ b/project/src/Ships/Stats.gd
@@ -61,7 +61,7 @@ func reset() -> void:
 
 # Calculates the final value of a single stat, its based value with all modifiers applied.
 func _update(stat: String = "") -> void:
-	var value_start: float = self.get(stat)
+	var value_start: float = self.get(_stats_list[stat])
 	var value = value_start
 	for modifier in _modifiers[stat]:
 		value += modifier
@@ -76,7 +76,7 @@ func _update_all() -> void:
 
 
 # Returns a list of stat properties as strings.
-func _get_stats_list() -> PoolStringArray:
+func _get_stats_list() -> Dictionary:
 	var ignore := [
 		"resource_local_to_scene",
 		"resource_name",
@@ -86,11 +86,11 @@ func _get_stats_list() -> PoolStringArray:
 		"_modifiers",
 		"_cache"
 	]
-	var stats := PoolStringArray()
+	var stats := {}
 	for p in get_property_list():
 		if p.name[0].capitalize() == p.name[0]:
 			continue
 		if p.name in ignore:
 			continue
-		stats.append(p.name)
+		stats[p.name.lstrip("_")] = p.name
 	return stats

--- a/project/src/Ships/Stats.gd
+++ b/project/src/Ships/Stats.gd
@@ -64,7 +64,7 @@ func _update(stat: String = "") -> void:
 	var value_start: float = self.get(stat)
 	var value = value_start
 	for modifier in _modifiers[stat]:
-		value += modifier.value
+		value += modifier
 	_cache[stat] = value
 	emit_signal("stat_changed", stat, value_start, value)
 

--- a/project/src/UI/PlayerUI.tscn
+++ b/project/src/UI/PlayerUI.tscn
@@ -1,6 +1,9 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=7 format=2]
 
-[sub_resource type="StyleBoxFlat" id=3]
+[ext_resource path="res://src/Ships/Player/PlayerShipUI.gd" type="Script" id=1]
+[ext_resource path="res://src/Ships/Player/AnimatedBar.gd" type="Script" id=2]
+
+[sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 0.870588, 0.129412, 0.129412, 1 )
 border_width_left = 2
 border_width_top = 2
@@ -12,7 +15,7 @@ corner_radius_top_right = 20
 corner_radius_bottom_right = 20
 corner_radius_bottom_left = 20
 
-[sub_resource type="StyleBoxFlat" id=4]
+[sub_resource type="StyleBoxFlat" id=2]
 bg_color = Color( 0.34902, 0.0588235, 0.0588235, 1 )
 border_width_left = 2
 border_width_top = 2
@@ -24,7 +27,7 @@ corner_radius_top_right = 20
 corner_radius_bottom_right = 20
 corner_radius_bottom_left = 20
 
-[sub_resource type="StyleBoxFlat" id=1]
+[sub_resource type="StyleBoxFlat" id=3]
 bg_color = Color( 0.129412, 0.870588, 0.52549, 1 )
 border_width_left = 2
 border_width_top = 2
@@ -36,7 +39,7 @@ corner_radius_top_right = 20
 corner_radius_bottom_right = 20
 corner_radius_bottom_left = 20
 
-[sub_resource type="StyleBoxFlat" id=2]
+[sub_resource type="StyleBoxFlat" id=4]
 bg_color = Color( 0.0588235, 0.34902, 0.192157, 1 )
 border_width_left = 2
 border_width_top = 2
@@ -48,7 +51,7 @@ corner_radius_top_right = 20
 corner_radius_bottom_right = 20
 corner_radius_bottom_left = 20
 
-[node name="PlayerUI" type="VBoxContainer"]
+[node name="PlayerShipUI" type="VBoxContainer"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -57,29 +60,38 @@ margin_left = -25.0
 margin_top = -2.0
 margin_right = 25.0
 margin_bottom = 2.0
+script = ExtResource( 1 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Health" type="ProgressBar" parent="."]
+[node name="HealthBar" type="ProgressBar" parent="."]
 margin_right = 50.0
 margin_bottom = 10.0
 rect_min_size = Vector2( 50, 10 )
-custom_styles/fg = SubResource( 3 )
-custom_styles/bg = SubResource( 4 )
+custom_styles/fg = SubResource( 1 )
+custom_styles/bg = SubResource( 2 )
+step = 1.0
 percent_visible = false
+script = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Cargo" type="ProgressBar" parent="."]
+[node name="Tween" type="Tween" parent="HealthBar"]
+
+[node name="CargoBar" type="ProgressBar" parent="."]
 margin_top = 14.0
 margin_right = 50.0
 margin_bottom = 24.0
 rect_min_size = Vector2( 50, 10 )
-custom_styles/fg = SubResource( 1 )
-custom_styles/bg = SubResource( 2 )
+custom_styles/fg = SubResource( 3 )
+custom_styles/bg = SubResource( 4 )
+step = 1.0
 percent_visible = false
+script = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+
+[node name="Tween" type="Tween" parent="CargoBar"]


### PR DESCRIPTION
This PR is meant to close #24. It was longer than I expected as to make this flexible, we needed a solution to store arbitrary stats and apply upgrades to them. This is done with 9cc1bbe1e1eb23fe0206dd4d063d424849594e7e

This PR integrates Stats into the game. It:

- Replaces properties in PlayerShip and Cargo 
- Moves UI code in the PlayerShip and Cargo to the UI nodes themselves

## Left to do

Refactor and restore upgrades.